### PR TITLE
Implement production polish

### DIFF
--- a/apps/api/src/prompts.ts
+++ b/apps/api/src/prompts.ts
@@ -1,6 +1,7 @@
 export const extractPrompt = `
 Extrae la siguiente información de este documento.
 Si no encuentras algún campo, usa una cadena vacía.
+Si no encuentras la clave del medio no la inventes ni la incluyas en el JSON.
 El documento describe un conjunto de medios publicitarios.
 Si encuentras un formato como "MEDIDAS: 13.00 X 4.20 MTS.", extrae el primer número como base y el segundo como altura
 La base y altura se expresan en metros, utiliza el punto como separador decimal. Si no hay decimales, devuelvelo como entero en una cadena Ej: "13"

--- a/apps/frontend/app/media/page.tsx
+++ b/apps/frontend/app/media/page.tsx
@@ -78,8 +78,7 @@ export default function MediaPage() {
 
       const transformedItems: MediaFormData[] = mediaItems.map((item, index) => ({
         id: Math.random().toString(36).toString(),
-        // TODO: manejar casos sin clave!
-        claveZirkel: `ZM${provider!.clave}${item.clave || ''}`,
+        claveZirkel: item.clave ? `ZM${provider!.clave}${item.clave}` : '',
         claveOriginalSitio: item.clave || '',
         costo: item.costo,
         costoInstalacion: item.costoInstalacion,


### PR DESCRIPTION
## Summary
- alphabetically order slides by city
- trim address text and format measurements
- auto-generate missing keys for uploads
- write new rows in first empty slot using USER_ENTERED mode
- avoid incomplete keys in media UI

## Testing
- `pnpm lint` *(fails: Request was cancelled)*
- `pnpm build` *(fails: Request was cancelled)*
- `pnpm check-types` *(fails: Request was cancelled)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68603bd46020832bbfb7b56931c658d1